### PR TITLE
Add Strapi CMS backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Node modules
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Optional runtime data
+pids
+*.pid
+*.seed
+
+# dotenv environment variables
+.env
+
+# Build output
+build/
+.strapi/*
+
+# SQLite database
+backend/data/*.db
+
+# Strapi cache
+.cache/
+
+# Mac OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the initial prototype for **Streak**, a themed live streaming platform. The project is split into two main parts:
 
 - `frontend/` – a Next.js application with Tailwind CSS and Google/Twitch authentication via NextAuth.
-- `backend/` – placeholder for a future headless CMS implementation (e.g. Strapi).
+- `backend/` – Strapi headless CMS providing channel, streamer and transmission management.
 
 The frontend currently demonstrates channel selection, dynamic player updates based on the schedule, and simple authentication hooks. Environment variables for authentication providers can be configured in `.env.example`.
 
@@ -16,3 +16,13 @@ npm run dev
 ```
 
 Then open http://localhost:3000.
+
+### Backend CMS
+
+```bash
+cd backend
+npm install
+npm run develop
+```
+
+The backend exposes a custom endpoint `/api/live/:slug` to retrieve the current transmission for a channel.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,23 @@
+# Streak CMS
+
+This directory contains a Strapi project providing a headless CMS for the Streak streaming platform. The CMS defines three collection types:
+
+- **Streamer** – reusable streamer profiles
+- **Canale** – themed channels
+- **Trasmissione** – scheduled events linked to a channel and a streamer
+
+## Custom API
+
+- `GET /api/live/:slug` – returns the current transmission and upcoming slots for a given channel
+- `GET /api/canali` – list of channels
+- `GET /api/streamer` – list of streamers
+
+`Trasmissione` entries are validated to avoid overlapping time slots on the same channel.
+
+Run the CMS in development mode:
+
+```bash
+cd backend
+npm install
+npm run develop
+```

--- a/backend/config/admin.js
+++ b/backend/config/admin.js
@@ -1,0 +1,5 @@
+module.exports = ({ env }) => ({
+  auth: {
+    secret: env('ADMIN_JWT_SECRET', 'supersecret'),
+  },
+});

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -1,0 +1,9 @@
+module.exports = ({ env }) => ({
+  connection: {
+    client: 'sqlite',
+    connection: {
+      filename: env('DATABASE_FILENAME', './data/database.db'),
+    },
+    useNullAsDefault: true,
+  },
+});

--- a/backend/config/server.js
+++ b/backend/config/server.js
@@ -1,0 +1,7 @@
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  app: {
+    keys: env.array('APP_KEYS', ['someRandomKey1', 'someRandomKey2']),
+  },
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "streak-cms",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "develop": "strapi develop",
+    "start": "strapi start",
+    "build": "strapi build"
+  },
+  "dependencies": {
+    "@strapi/strapi": "^4.15.4",
+    "sqlite3": "^5.1.2"
+  }
+}

--- a/backend/src/api/canale/content-types/canale/schema.json
+++ b/backend/src/api/canale/content-types/canale/schema.json
@@ -1,0 +1,36 @@
+{
+  "collectionName": "canales",
+  "info": {
+    "singularName": "canale",
+    "pluralName": "canales",
+    "displayName": "Canale"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "nome": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "nome"
+    },
+    "descrizione": {
+      "type": "text"
+    },
+    "icona": {
+      "type": "string"
+    },
+    "colore_tema": {
+      "type": "string"
+    },
+    "trasmissioni": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::trasmissione.trasmissione"
+    }
+  }
+}

--- a/backend/src/api/canale/routes/canale.js
+++ b/backend/src/api/canale/routes/canale.js
@@ -1,0 +1,10 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/canali',
+      handler: 'canale.find',
+      config: { auth: false },
+    },
+  ],
+};

--- a/backend/src/api/live/controllers/live.js
+++ b/backend/src/api/live/controllers/live.js
@@ -1,0 +1,47 @@
+'use strict';
+
+module.exports = {
+  async findCurrent(ctx) {
+    const { slug } = ctx.params;
+    const channel = await strapi.entityService.findMany('api::canale.canale', {
+      filters: { slug },
+      populate: { trasmissioni: true },
+    });
+    if (!channel || channel.length === 0) {
+      return ctx.notFound();
+    }
+    const canale = channel[0];
+    const now = new Date();
+    const today = now.toISOString().split('T')[0];
+    const transmissions = await strapi.entityService.findMany('api::trasmissione.trasmissione', {
+      filters: { canale: canale.id, data: today },
+      populate: { streamer: true },
+      sort: { ora_inizio: 'asc' },
+    });
+    let current = null;
+    const upcoming = [];
+    for (const t of transmissions) {
+      const start = new Date(`${t.data}T${t.ora_inizio}`);
+      const end = new Date(start.getTime() + t.durata_minuti * 60000);
+      if (now >= start && now <= end) {
+        current = t;
+      } else if (start > now) {
+        upcoming.push({ orario: t.ora_inizio, titolo: t.titolo, streamer: t.streamer.nome });
+      }
+    }
+    ctx.send({
+      attuale: current
+        ? {
+            titolo: current.titolo,
+            streamer: {
+              nome: current.streamer.nome,
+              avatar: current.streamer.avatar,
+              social_links: current.streamer.social_links,
+            },
+            codice_embed: current.codice_embed,
+          }
+        : null,
+      prossime: upcoming,
+    });
+  },
+};

--- a/backend/src/api/live/routes/live.js
+++ b/backend/src/api/live/routes/live.js
@@ -1,0 +1,12 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/live/:slug',
+      handler: 'live.findCurrent',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/backend/src/api/live/services/live.js
+++ b/backend/src/api/live/services/live.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  // service placeholder
+};

--- a/backend/src/api/streamer/content-types/streamer/schema.json
+++ b/backend/src/api/streamer/content-types/streamer/schema.json
@@ -1,0 +1,40 @@
+{
+  "collectionName": "streamers",
+  "info": {
+    "singularName": "streamer",
+    "pluralName": "streamers",
+    "displayName": "Streamer"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "nome": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "nome"
+    },
+    "avatar": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
+    },
+    "piattaforma": {
+      "type": "enumeration",
+      "enum": ["twitch", "youtube", "kick"]
+    },
+    "social_links": {
+      "type": "json"
+    },
+    "trasmissioni": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::trasmissione.trasmissione"
+    }
+  }
+}

--- a/backend/src/api/streamer/routes/streamer.js
+++ b/backend/src/api/streamer/routes/streamer.js
@@ -1,0 +1,10 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/streamer',
+      handler: 'streamer.find',
+      config: { auth: false },
+    },
+  ],
+};

--- a/backend/src/api/trasmissione/content-types/trasmissione/lifecycles.js
+++ b/backend/src/api/trasmissione/content-types/trasmissione/lifecycles.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async beforeCreate(event) {
+    await validateNoOverlap(event.params.data, strapi);
+  },
+  async beforeUpdate(event) {
+    await validateNoOverlap(event.params.data, strapi, event.params.where.id);
+  },
+};
+
+async function validateNoOverlap(data, strapiInstance, currentId) {
+  if (!data.canale || !data.data || !data.ora_inizio || !data.durata_minuti) return;
+  const start = new Date(`${data.data}T${data.ora_inizio}`);
+  const end = new Date(start.getTime() + data.durata_minuti * 60000);
+  const query = {
+    filters: {
+      canale: data.canale,
+      data: data.data,
+    },
+  };
+  const existing = await strapiInstance.entityService.findMany('api::trasmissione.trasmissione', query);
+  for (const t of existing) {
+    if (currentId && t.id === currentId) continue;
+    const tStart = new Date(`${t.data}T${t.ora_inizio}`);
+    const tEnd = new Date(tStart.getTime() + t.durata_minuti * 60000);
+    if (start < tEnd && end > tStart) {
+      throw new Error('Overlapping trasmissione on this canale');
+    }
+  }
+}

--- a/backend/src/api/trasmissione/content-types/trasmissione/schema.json
+++ b/backend/src/api/trasmissione/content-types/trasmissione/schema.json
@@ -1,0 +1,40 @@
+{
+  "collectionName": "trasmissiones",
+  "info": {
+    "singularName": "trasmissione",
+    "pluralName": "trasmissiones",
+    "displayName": "Trasmissione"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "canale": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::canale.canale",
+      "inversedBy": "trasmissioni"
+    },
+    "streamer": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::streamer.streamer",
+      "inversedBy": "trasmissioni"
+    },
+    "data": {
+      "type": "date"
+    },
+    "ora_inizio": {
+      "type": "time"
+    },
+    "durata_minuti": {
+      "type": "integer"
+    },
+    "titolo": {
+      "type": "string"
+    },
+    "codice_embed": {
+      "type": "text"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `.gitignore`
- introduce Strapi backend with collection types (Streamer, Canale, Trasmissione)
- add custom live endpoint with time overlap validation
- update project README and document backend

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686993391a2c8330a1155eb3da15e74f