### PR TITLE
Add basic test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ npm run develop
 ```
 
 The backend exposes a custom endpoint `/api/live/:slug` to retrieve the current transmission for a channel.
+
+## Testing
+
+Run unit tests for the frontend and backend with:
+
+```bash
+cd frontend && npm install && npm test
+```
+
+```bash
+cd backend && npm install && npm test
+```

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,10 +5,15 @@
   "scripts": {
     "develop": "strapi develop",
     "start": "strapi start",
-    "build": "strapi build"
+    "build": "strapi build",
+    "test": "jest"
   },
   "dependencies": {
     "@strapi/strapi": "^4.15.4",
     "sqlite3": "^5.1.2"
+  },
+  "devDependencies": {
+    "jest": "^29",
+    "supertest": "^6"
   }
 }

--- a/backend/tests/smoke.test.js
+++ b/backend/tests/smoke.test.js
@@ -1,0 +1,3 @@
+test('basic math works', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "date-fns": "^2.30.0",
@@ -22,6 +23,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/jest": "^29",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/user-event": "^14",
+    "jest": "^29",
+    "jest-environment-jsdom": "^29",
+    "ts-jest": "^29",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/frontend/tests/data.test.ts
+++ b/frontend/tests/data.test.ts
@@ -1,0 +1,7 @@
+import { streamers } from '../src/lib/data';
+
+describe('sample data', () => {
+  it('contains two streamers', () => {
+    expect(streamers).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and a simple smoke test for backend
- add Jest config and example data test for frontend
- document how to run tests locally

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68699ab23d10833086588cb4f866f5f5