### PR TITLE
Add unified dev runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,25 @@ The frontend currently demonstrates channel selection, dynamic player updates ba
 
 ## Development
 
+Start both the frontend and backend together using the helper script:
+
+```bash
+node dev.js
+```
+
+This launches the frontend on <http://localhost:3000> and the Strapi admin on
+<http://localhost:1337/admin>. Refresh either page after modifying code to see
+the changes.
+
+### Run parts individually
+
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-Then open http://localhost:3000.
+Then open <http://localhost:3000>.
 
 ### Backend CMS
 

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+
+function openBrowser(url) {
+  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  spawn(command, [url], { stdio: 'ignore', detached: true, shell: true });
+}
+
+const backend = spawn('npm', ['run', 'develop'], {
+  cwd: 'backend',
+  stdio: 'inherit',
+  shell: true,
+});
+
+const frontend = spawn('npm', ['run', 'dev'], {
+  cwd: 'frontend',
+  stdio: 'inherit',
+  shell: true,
+});
+
+setTimeout(() => {
+  openBrowser('http://localhost:3000');
+  openBrowser('http://localhost:1337/admin');
+}, 5000);
+
+function cleanup() {
+  backend.kill('SIGINT');
+  frontend.kill('SIGINT');
+}
+
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit();
+});
+process.on('exit', cleanup);


### PR DESCRIPTION
## Summary
- create `dev.js` script to start frontend and backend simultaneously
- document the helper script in README

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_686a485b7f8c8330a494fd33b7e95815