### PR TITLE
Generate Excel template dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The frontend currently demonstrates channel selection, dynamic player updates ba
 
 ## Development
 
---- q0258z-codex/crea-eseguibile-per-backend-e-frontend
 Start both the frontend and backend together from the repository root. The `dev` script uses `dev.js` to launch both apps and will install sub-project dependencies on first run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ npm run setup
 # start the development servers and open the browser
 npm run dev
 
-Start both the frontend and backend together using the helper script:
-
-```bash
-node dev.js
-main
-```
+On Windows you can simply double click `start.bat`. The script installs all dependencies on first run, starts both servers and keeps the console window open so you can read any messages. When the servers are ready your default browser opens automatically.
 
 This launches the frontend on <http://localhost:3000> and the Strapi admin on
 <http://localhost:1337/admin>. Refresh either page after modifying code to see
@@ -49,6 +44,11 @@ npm run develop
 ```
 
 The backend exposes a custom endpoint `/api/live/:slug` to retrieve the current transmission for a channel.
+
+Additional endpoints are available to import a schedule via Excel. The template is generated dynamically by the backend:
+
+- `GET /api/palinsesto/template` – download the Excel template.
+- `POST /api/palinsesto/upload` – upload the filled template.
 
 ## Testing
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@strapi/strapi": "^4.15.4",
-    "sqlite3": "^5.1.2"
+    "sqlite3": "^5.1.2",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "jest": "^29",

--- a/backend/src/api/palinsesto/controllers/palinsesto.js
+++ b/backend/src/api/palinsesto/controllers/palinsesto.js
@@ -1,0 +1,66 @@
+'use strict';
+const xlsx = require('xlsx');
+
+module.exports = {
+  async downloadTemplate(ctx) {
+    const wb = xlsx.utils.book_new();
+    const ws = xlsx.utils.aoa_to_sheet([
+      [
+        'Data',
+        'OraInizio',
+        'DurataMinuti',
+        'CanaleSlug',
+        'StreamerSlug',
+        'Titolo',
+        'CodiceEmbed',
+      ],
+    ]);
+    xlsx.utils.book_append_sheet(wb, ws, 'Template');
+    const buffer = xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+    ctx.set('Content-disposition', 'attachment; filename=palinsesto_template.xlsx');
+    ctx.set('Content-type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    ctx.body = buffer;
+  },
+
+  async upload(ctx) {
+    const { files } = ctx.request;
+    if (!files || !files.file) {
+      return ctx.badRequest('No file uploaded');
+    }
+    const workbook = xlsx.readFile(files.file.path);
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const data = xlsx.utils.sheet_to_json(sheet);
+
+    for (const row of data) {
+      const channel = await findChannelBySlug(row.CanaleSlug);
+      const streamer = await findStreamerBySlug(row.StreamerSlug);
+      if (!channel || !streamer) continue;
+      await strapi.entityService.create('api::trasmissione.trasmissione', {
+        data: {
+          data: row.Data,
+          ora_inizio: row.OraInizio,
+          durata_minuti: row.DurataMinuti,
+          titolo: row.Titolo,
+          codice_embed: row.CodiceEmbed || '',
+          canale: channel.id,
+          streamer: streamer.id,
+        },
+      });
+    }
+    ctx.send({ imported: data.length });
+  },
+};
+
+async function findChannelBySlug(slug) {
+  const res = await strapi.entityService.findMany('api::canale.canale', {
+    filters: { slug },
+  });
+  return res[0];
+}
+
+async function findStreamerBySlug(slug) {
+  const res = await strapi.entityService.findMany('api::streamer.streamer', {
+    filters: { slug },
+  });
+  return res[0];
+}

--- a/backend/src/api/palinsesto/routes/palinsesto.js
+++ b/backend/src/api/palinsesto/routes/palinsesto.js
@@ -1,0 +1,16 @@
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/palinsesto/template',
+      handler: 'palinsesto.downloadTemplate',
+      config: { auth: false },
+    },
+    {
+      method: 'POST',
+      path: '/palinsesto/upload',
+      handler: 'palinsesto.upload',
+      config: { auth: false },
+    },
+  ],
+};

--- a/backend/src/api/palinsesto/services/palinsesto.js
+++ b/backend/src/api/palinsesto/services/palinsesto.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = {};

--- a/dev.js
+++ b/dev.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+const { spawn } = require('child_process');
+const waitOn = require('wait-on');
+const open = require('open');
 
 const backend = spawn('npm', ['run', 'develop'], {
   cwd: 'backend',
@@ -30,12 +33,6 @@ waitOn({ resources: ['http://localhost:3000', 'http://localhost:1337/admin'] })
   .catch((err) => {
     console.error('Error waiting for servers to start', err);
   });
-=======
-setTimeout(() => {
-  openBrowser('http://localhost:3000');
-  openBrowser('http://localhost:1337/admin');
-}, 5000);
- main
 
 function cleanup() {
   backend.kill('SIGINT');

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -12,6 +12,23 @@ export default function AdminPage() {
   const [streamers, setStreamers] = useState<Streamer[]>([]);
   const [transmissions, setTransmissions] = useState<Transmission[]>([]);
 
+  const handleDownload = () => {
+    window.open('/api/palinsesto/template', '_blank');
+  };
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    await fetch('/api/palinsesto/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    alert('File uploaded');
+    e.target.value = '';
+  };
+
   useEffect(() => {
     fetch('/api/data')
       .then((r) => r.json())
@@ -46,6 +63,16 @@ export default function AdminPage() {
           Logout
         </button>
       </header>
+
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={handleDownload}
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+        >
+          Scarica template
+        </button>
+        <input type="file" accept=".xlsx" onChange={handleUpload} />
+      </div>
 
       <Calendar transmissions={transmissions} channels={channels} />
     </div>

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,33 @@
+@echo off
+setlocal
+cd /d %~dp0
+if not exist node_modules (
+    echo Installing root dependencies...
+    npm install --legacy-peer-deps
+)
+if not exist frontend\node_modules (
+    echo Installing frontend dependencies...
+    npm install --prefix frontend --legacy-peer-deps
+)
+if not exist backend\node_modules (
+    echo Installing backend dependencies...
+    npm install --prefix backend --legacy-peer-deps
+)
+where node >NUL 2>&1
+if %errorlevel% neq 0 (
+    echo Node.js is required but was not found in your PATH.
+    pause
+    exit /b 1
+)
+
+where npm >NUL 2>&1
+if %errorlevel% neq 0 (
+    echo npm is required but was not found in your PATH.
+    pause
+    exit /b 1
+)
+
+echo Starting development servers...
+node dev.js
+pause
+endlocal


### PR DESCRIPTION
## Summary
- generate Excel template on the fly
- remove binary template file
- use relative URLs in admin upload/download handlers
- clarify dev instructions in README
- add `start.bat` for one-click Windows setup and launch
- keep `start.bat` console open and verify Node/npm

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa35c283883308bd218b9d84d053b